### PR TITLE
Potential fix for code scanning alert no. 14: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/ASPPowerShell/ASPPowerShell/bin/ASPPowerShell.dll.config
+++ b/ASPPowerShell/ASPPowerShell/bin/ASPPowerShell.dll.config
@@ -5,7 +5,7 @@
   -->
 <configuration>
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2"/>
+    <compilation targetFramework="4.7.2"/>
     <httpRuntime targetFramework="4.7.2"/>
     <pages>
       <namespaces>


### PR DESCRIPTION
Potential fix for [https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/14](https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/14)

To resolve the issue, the `debug` attribute in the `<compilation>` element should be set to `false` or removed entirely. This ensures that the application does not expose sensitive debugging information or suffer from performance degradation in production environments. The change should be made directly in the `ASPPowerShell.dll.config` file on line 8.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
