### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/ASPPowerShell/packages/jQuery.3.4.1/Content/Scripts/jquery-3.4.1.slim.js
+++ b/ASPPowerShell/packages/jQuery.3.4.1/Content/Scripts/jquery-3.4.1.slim.js
@@ -5774,7 +5774,7 @@ var
 	/* eslint-disable max-len */
 
 	// See https://github.com/eslint/eslint/issues/3229
-	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
+	// Removed unsafe rxhtmlTag regular expression
 
 	/* eslint-enable */
 
@@ -5976,7 +5976,22 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		var parser = new DOMParser();
+		var doc = parser.parseFromString(html, "text/html");
+
+		// Convert self-closing tags to open/close pairs
+		doc.querySelectorAll("*").forEach(function(node) {
+			if (node.outerHTML.endsWith("/>")) {
+				var parent = node.parentNode;
+				var newNode = document.createElement(node.tagName);
+				Array.from(node.attributes).forEach(function(attr) {
+					newNode.setAttribute(attr.name, attr.value);
+				});
+				parent.replaceChild(newNode, node);
+			}
+		});
+
+		return doc.body.innerHTML;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/4](https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/4)

To fix the issue, we need to replace the unsafe transformation in the `htmlPrefilter` function with a safer approach. Instead of using a regular expression to expand self-closing tags, we should rely on a well-tested HTML parser or library that can safely handle HTML transformations. This ensures that the input is processed correctly without introducing vulnerabilities.

The best way to fix this is to use a library like DOMParser (built into modern browsers) to parse the HTML string into a DOM structure, modify it as needed, and then serialize it back to a string. This approach avoids the pitfalls of regular expressions and ensures that the HTML structure remains valid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
