### PR TITLE
Potential fix for code scanning alert no. 13: Prototype-polluting function

### DIFF
--- a/ASPPowerShell/packages/jQuery.3.4.1/Content/Scripts/jquery-3.4.1-vsdoc.js
+++ b/ASPPowerShell/packages/jQuery.3.4.1/Content/Scripts/jquery-3.4.1-vsdoc.js
@@ -1566,6 +1566,11 @@
             if ((options = arguments[i]) != null) {
                 // Extend the base object
                 for (name in options) {
+                    // Skip prototype-polluting properties
+                    if (name === "__proto__" || name === "constructor") {
+                        continue;
+                    }
+
                     src = target[name];
                     copy = options[name];
 


### PR DESCRIPTION
Potential fix for [https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/13](https://github.com/browninfosecguy/PowerShell-CSharp/security/code-scanning/13)

To fix the issue, we will modify the `jQuery.extend` function to block the `__proto__` and `constructor` properties from being copied. This approach ensures that malicious keys cannot be used to pollute the prototype chain. Specifically:
1. Add a check inside the `for (name in options)` loop to skip `__proto__` and `constructor`.
2. Ensure this check is applied before any assignment or recursive calls.

The fix will be applied to the `jQuery.extend` function in the file `ASPPowerShell/packages/jQuery.3.4.1/Content/Scripts/jquery-3.4.1-vsdoc.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
